### PR TITLE
Removed some Socket.IO options in favor of defaults. Closes #16.

### DIFF
--- a/server/bin/www
+++ b/server/bin/www
@@ -34,7 +34,6 @@ console.log('Server listening on port ' + port);
 /**
  * Attach Socket.IO to server
  */
-//app.io.attach(server, { 'pingInterval': '2000', 'pingTimeout': '5000' });
 app.io.attach(server);
 
 /**


### PR DESCRIPTION
Didn't realize it was commented out already, but now it's gone for good.